### PR TITLE
ユーザーの性別をEnumで置換

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,6 +15,8 @@ class User < ApplicationRecord
   # validates :gender, presence: true
   # validates :age, presence: true
 
+  enum gender: { "男性" => "男性", "女性" => "女性", "その他" => "その他" }
+
   # 渡された文字列のハッシュ値を返す
   def self.digest(string)
     cost = ActiveModel::SecurePassword.min_cost ? BCrypt::Engine::MIN_COST :

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -17,7 +17,7 @@
           <%= f.select :age, [["10~20代","10~20代"],["30代","30代"],["40代","40代"],["50代","50代"],["60代以上","60代以上"]], {prompt:"選択してください"}, {class: 'form-control'} %>
 
           <%= f.label :性別 %>
-          <%= f.select :gender, [["男性","男性"],["女性","女性"],["その他","その他"]], {prompt:"選択してください"}, {class: 'form-control'} %>
+          <%= f.select :gender, User.genders, {prompt:"選択してください"}, {class: 'form-control'} %>
 
           <%= f.label :パスワード %>
           <%= f.password_field :password, class: 'form-control' %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -21,7 +21,7 @@
           <%= f.select :age, [["10~20代","10~20代"],["30代","30代"],["40代","40代"],["50代","50代"],["60代以上","60代以上"]], {prompt:"選択してください"}, {class: 'form-control'} %>
 
           <%= f.label :性別 %>
-          <%= f.select :gender, [["男性","男性"],["女性","女性"],["その他","その他"]], {prompt:"選択してください"}, {class: 'form-control'} %>
+          <%= f.select :gender, User.genders, {prompt:"選択してください"}, {class: 'form-control'} %>
 
           <%= f.label :パスワード %>
           <%= f.password_field :password, class: 'form-control' %>


### PR DESCRIPTION
あまりいい実装ではありませんが、他の個所への影響を考えて以下のようにEnumで性別を選択できるようにしました

```ruby
enum gender: { "男性" => "男性", "女性" => "女性", "その他" => "その他" }
```